### PR TITLE
Sort table keys in cleanup_table_ddl()

### DIFF
--- a/ddldump/constants.py
+++ b/ddldump/constants.py
@@ -1,1 +1,1 @@
-VERSION = '0.3'
+VERSION = "0.3.1"

--- a/ddldump/constants.py
+++ b/ddldump/constants.py
@@ -1,1 +1,1 @@
-VERSION = "0.3.1"
+VERSION = "0.4"

--- a/ddldump/main.py
+++ b/ddldump/main.py
@@ -158,8 +158,9 @@ def _show_create_postgresql(engine, table):
 
 def sort_table_keys(raw_ddl):
     """
-    Sort the lines of the raw table DDL beginning with KEY, so that no matter what order the
-    keys were added in, the resulting DDL outputs are identical.
+    Sort the lines of the raw table DDL beginning with KEY, so that no matter
+    what order the keys were added in, the resulting DDL outputs are
+    identical.
 
     Args:
         raw_ddl (basestring)
@@ -195,7 +196,7 @@ def cleanup_table_ddl(raw_ddl):
     key_sorted_ddl = sort_table_keys(raw_ddl)
 
     # Removing the AUTOINC state from the CREATE TABLE
-    clean_ddl = re.sub(" AUTO_INCREMENT=\d+", u"", key_sorted_ddl)
+    clean_ddl = re.sub(r" AUTO_INCREMENT=\d+", u"", key_sorted_ddl)
 
     return clean_ddl
 

--- a/ddldump/main.py
+++ b/ddldump/main.py
@@ -169,13 +169,22 @@ def sort_table_keys(raw_ddl):
         basestring
     """
     lines = raw_ddl.split("\n")
+    key_lines = [l for l in lines if l.strip().startswith("KEY")]
+
+    if not key_lines:
+        return raw_ddl
+
+    last_has_comma = key_lines[-1][-1] == ','
     sorted_key_lines = sorted([
-        (l, i) for i, l in enumerate(lines) if l.strip().startswith("KEY")
+        (l if l[-1] != ',' else l[:-1], i)
+        for i, l in enumerate(key_lines)
     ])
     key_line_idxs = set([i for l, i in sorted_key_lines])
     for i, _ in enumerate(lines):
         if i in key_line_idxs:
             lines[i] = sorted_key_lines.pop(0)[0]
+            if sorted_key_lines or last_has_comma:
+                lines[i] += ','
     key_sorted_ddl = "\n".join(lines)
 
     return key_sorted_ddl

--- a/ddldump/main.py
+++ b/ddldump/main.py
@@ -169,16 +169,17 @@ def sort_table_keys(raw_ddl):
         basestring
     """
     lines = raw_ddl.split("\n")
-    key_lines = [l for l in lines if l.strip().startswith("KEY")]
+    key_lines = [(l, i) for i, l in enumerate(lines) if l.strip().startswith("KEY")]
 
     if not key_lines:
         return raw_ddl
 
-    last_has_comma = key_lines[-1][-1] == ','
+    last_has_comma = key_lines[-1][0][-1] == ','
     sorted_key_lines = sorted([
         (l if l[-1] != ',' else l[:-1], i)
-        for i, l in enumerate(key_lines)
+        for l, i in key_lines
     ])
+
     key_line_idxs = set([i for l, i in sorted_key_lines])
     for i, _ in enumerate(lines):
         if i in key_line_idxs:

--- a/ddldump/main.py
+++ b/ddldump/main.py
@@ -169,7 +169,11 @@ def sort_table_keys(raw_ddl):
         basestring
     """
     lines = raw_ddl.split("\n")
-    key_lines = [(l, i) for i, l in enumerate(lines) if l.strip().startswith("KEY")]
+    key_lines = [
+        (l, i)
+        for i, l in enumerate(lines)
+        if l.strip().startswith("KEY")
+    ]
 
     if not key_lines:
         return raw_ddl
@@ -180,7 +184,7 @@ def sort_table_keys(raw_ddl):
         for l, i in key_lines
     ])
 
-    key_line_idxs = set([i for l, i in sorted_key_lines])
+    key_line_idxs = set([i for _, i in sorted_key_lines])
     for i, _ in enumerate(lines):
         if i in key_line_idxs:
             lines[i] = sorted_key_lines.pop(0)[0]

--- a/ddldump_mysql.sql
+++ b/ddldump_mysql.sql
@@ -24,7 +24,7 @@ CREATE TABLE `record` (
   `added_on` datetime DEFAULT NULL,
   `type` int(11) NOT NULL COMMENT 'Type of record',
   PRIMARY KEY (`id`),
-  KEY `IDX_record_added_on` (`added_on`)
+  KEY `IDX_record_added_on` (`added_on`),
   KEY `record_type` (`type`),
-  KEY `recordurlsha1html` (`htmlurl_sha1`),
+  KEY `recordurlsha1html` (`htmlurl_sha1`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=COMPRESSED;

--- a/ddldump_mysql.sql
+++ b/ddldump_mysql.sql
@@ -24,7 +24,7 @@ CREATE TABLE `record` (
   `added_on` datetime DEFAULT NULL,
   `type` int(11) NOT NULL COMMENT 'Type of record',
   PRIMARY KEY (`id`),
+  KEY `IDX_record_added_on` (`added_on`)
   KEY `record_type` (`type`),
   KEY `recordurlsha1html` (`htmlurl_sha1`),
-  KEY `IDX_record_added_on` (`added_on`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=COMPRESSED;


### PR DESCRIPTION
Context: When running an alembic upgrade that removes a key (where there are multiple keys and the key is not the last one added), and then running the downgrade that replaces it, the `SHOW CREATE TABLE` output differs because the removed key has now been placed after the other keys. This change is to ensure that the output stays consistent by sorting the lines that begin with `KEY` in each table DDL. 

This will change the output of `ddldump` compared to the previous version, which may not be ideal for some users, so the version has been incremented by a minor version.