### PR TITLE
removing basestring and other requirements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,9 @@ jobs:
           name: Load ddldump postgres schema
           command: psql -h 127.0.0.1 -U postgres < ddldump_postgres.sql
       - run:
+          name: Install postgres driver for python
+          command: pip install psycopg2
+      - run:
           name: Package the repo into a wheel
           command: python setup.py bdist_wheel
       - run:
@@ -73,6 +76,9 @@ jobs:
       - run:
           name: Load ddldump postgres schema
           command: psql -h 127.0.0.1 -U postgres < ddldump_postgres.sql
+      - run:
+          name: Install postgres driver for python
+          command: pip3 install psycopg2
       - run:
           name: Package the repo into a wheel
           command: python3 setup.py bdist_wheel
@@ -109,6 +115,9 @@ jobs:
           name: Load ddldump mysql schema (with foreign key checks disabled)
           command: ( echo "SET FOREIGN_KEY_CHECKS=0; "; cat ddldump_mysql.sql ) | mysql -h 127.0.0.1 ddldump
       - run:
+          name: Install mysql driver for python
+          command: pip install mysqlclient
+      - run:
           name: Package the repo into a wheel
           command: python setup.py bdist_wheel
       - run:
@@ -144,6 +153,9 @@ jobs:
       - run:
           name: Load ddldump mysql schema (with foreign key checks disabled)
           command: ( echo "SET FOREIGN_KEY_CHECKS=0; "; cat ddldump_mysql.sql ) | mysql -h 127.0.0.1 ddldump
+      - run:
+          name: Install mysql driver for python
+          command: pip3 install mysqlclient
       - run:
           name: Package the repo into a wheel
           command: python3 setup.py bdist_wheel

--- a/ddldump/constants.py
+++ b/ddldump/constants.py
@@ -1,1 +1,1 @@
-VERSION = "0.6"
+VERSION = "0.6.1"

--- a/ddldump/main.py
+++ b/ddldump/main.py
@@ -24,6 +24,8 @@ Options:
                     in sync, e.g. during your continuous integration.
 
 """
+from __future__ import unicode_literals
+
 import logging
 import re
 import sys
@@ -40,7 +42,6 @@ from sqlalchemy import create_engine, MetaData, Table
 from sqlalchemy.sql.expression import select, asc
 
 from ddldump.constants import VERSION
-from past.builtins import basestring
 
 
 class Database(object):
@@ -248,10 +249,10 @@ def sort_table_keys(raw_ddl):
     identical.
 
     Args:
-        raw_ddl (basestring)
+        raw_ddl (unicode)
 
     Returns:
-        basestring
+        unicode
     """
     lines = raw_ddl.split("\n")
     key_lines = [(l, i) for i, l in enumerate(lines) if l.strip().startswith("KEY")]
@@ -280,17 +281,17 @@ def cleanup_table_ddl(raw_ddl):
     Given a raw DDL, clean it up to remove any varying piece, like AUTOINCs.
 
     Args:
-        raw_ddl (basestring)
+        raw_ddl (unicode)
 
     Returns:
-        basestring
+        unicode
     """
-    assert isinstance(raw_ddl, basestring)
+    assert isinstance(raw_ddl, unicode)
 
     key_sorted_ddl = sort_table_keys(raw_ddl)
 
     # Removing the AUTOINC state from the CREATE TABLE
-    clean_ddl = re.sub(r" AUTO_INCREMENT=\d+", u"", key_sorted_ddl)
+    clean_ddl = re.sub(r" AUTO_INCREMENT=\d+", "", key_sorted_ddl)
 
     return clean_ddl
 

--- a/ddldump/main.py
+++ b/ddldump/main.py
@@ -286,8 +286,6 @@ def cleanup_table_ddl(raw_ddl):
     Returns:
         unicode
     """
-    assert isinstance(raw_ddl, unicode)
-
     key_sorted_ddl = sort_table_keys(raw_ddl)
 
     # Removing the AUTOINC state from the CREATE TABLE

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
               'pg_dump'),
     license='GPLv3',
     packages=['ddldump'],
-    install_requires=['docopt', 'sqlalchemy', 'psycopg2', 'mysqlclient', 'future'],
+    install_requires=['docopt', 'sqlalchemy'],
     entry_points={
         'console_scripts': [
             'ddldump=ddldump.main:main',


### PR DESCRIPTION
Responding to  https://github.com/percolate/hotlanta/pull/17844#issuecomment-528570317

- not specifying database drivers
- SQLA returns unicode, not basestring, no need to handle basestring specifically.