### PR TITLE
ddldump should ignore the definer clause on VIEWS

### DIFF
--- a/ddldump/constants.py
+++ b/ddldump/constants.py
@@ -1,1 +1,1 @@
-VERSION = "0.6.1"
+VERSION = "0.6.2"

--- a/ddldump/main.py
+++ b/ddldump/main.py
@@ -288,8 +288,11 @@ def cleanup_table_ddl(raw_ddl):
     """
     key_sorted_ddl = sort_table_keys(raw_ddl)
 
-    # Removing the AUTOINC state from the CREATE TABLE
+    # Removing the AUTOINC state from CREATE TABLE statements
     clean_ddl = re.sub(r" AUTO_INCREMENT=\d+", "", key_sorted_ddl)
+
+    # Removing the DEFINE clause from CREATE VIEW statements
+    clean_ddl = re.sub(r" DEFINER=`\w+.*SQL", " SQL", clean_ddl)
 
     return clean_ddl
 

--- a/ddldump_mysql.sql
+++ b/ddldump_mysql.sql
@@ -39,4 +39,4 @@ CREATE TABLE `record_audit` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 
 -- Create syntax for TABLE 'custom_record_view'
-CREATE ALGORITHM=UNDEFINED DEFINER=`percolate`@`%` SQL SECURITY DEFINER VIEW `custom_record_view` AS (select `c`.`id` AS `id`,`r`.`id` AS `subject_id` from (`custom_record` `c` join `record` `r` on((`c`.`id` = `r`.`id`))) where ((`r`.`type` in ('new','in_progress','complete')) and isnull(`c`.`added_on`)));
+CREATE ALGORITHM=UNDEFINED SQL SECURITY DEFINER VIEW `custom_record_view` AS (select `c`.`id` AS `id`,`r`.`id` AS `subject_id` from (`custom_record` `c` join `record` `r` on((`c`.`id` = `r`.`id`))) where ((`r`.`type` in ('new','in_progress','complete')) and isnull(`c`.`added_on`)));


### PR DESCRIPTION
Dumping the definer clause makes the views unusable because we have different users across devolate, CCI, and prod and it would break the ddldump test and the cci workflow.